### PR TITLE
PendingIntent FLAG_IMMUTABLE or FLAG_MUTABLE flag issue at target version 31

### DIFF
--- a/library/src/main/java/com/download/library/DownloadNotifier.java
+++ b/library/src/main/java/com/download/library/DownloadNotifier.java
@@ -105,12 +105,12 @@ public class DownloadNotifier {
 
     void initBuilder(DownloadTask downloadTask) {
         String title = getTitle(downloadTask);
-        this.mDownloadTask = downloadTask;
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
-        } else {
-            mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT));
+            flags |= PendingIntent.FLAG_IMMUTABLE;
         }
+        this.mDownloadTask = downloadTask;
+        mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), flags));
         mBuilder.setSmallIcon(mDownloadTask.getDownloadIcon());
         mBuilder.setTicker(mContext.getString(R.string.download_trickter));
         mBuilder.setContentTitle(title);
@@ -143,12 +143,11 @@ public class DownloadNotifier {
     private PendingIntent buildCancelContent(Context context, int id, String url) {
         Intent intentCancel = new Intent(Runtime.getInstance().append(context, NotificationCancelReceiver.ACTION));
         intentCancel.putExtra("TAG", url);
-        PendingIntent pendingIntentCancel;
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-        } else {
-            pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, PendingIntent.FLAG_UPDATE_CURRENT);
+            flags |= PendingIntent.FLAG_IMMUTABLE;
         }
+        PendingIntent pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, flags);
         Runtime.getInstance().log(TAG, "buildCancelContent id:" + (id * 1000) + " cancal action:" + Runtime.getInstance().append(context, NotificationCancelReceiver.ACTION));
         return pendingIntentCancel;
     }
@@ -289,18 +288,12 @@ public class DownloadNotifier {
                 public void run() {
                     removeCancelAction();
                     setDelecte(null);
-                    PendingIntent rightPendIntent;
+                    int flags = PendingIntent.FLAG_UPDATE_CURRENT;
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        rightPendIntent = PendingIntent
-                          .getActivity(mContext,
-                            mNotificationId * 10000, mIntent,
-                            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-                    } else {
-                        rightPendIntent = PendingIntent
-                          .getActivity(mContext,
-                            mNotificationId * 10000, mIntent,
-                            PendingIntent.FLAG_UPDATE_CURRENT);
+                        flags |= PendingIntent.FLAG_IMMUTABLE;
                     }
+                    PendingIntent rightPendIntent = PendingIntent
+                      .getActivity(mContext, mNotificationId * 10000, mIntent, flags);
                     mBuilder.setSmallIcon(mDownloadTask.getDownloadDoneIcon());
                     mBuilder.setContentText(mContext.getString(R.string.download_click_open));
                     mBuilder.setProgress(100, 100, false);

--- a/library/src/main/java/com/download/library/DownloadNotifier.java
+++ b/library/src/main/java/com/download/library/DownloadNotifier.java
@@ -106,7 +106,11 @@ public class DownloadNotifier {
     void initBuilder(DownloadTask downloadTask) {
         String title = getTitle(downloadTask);
         this.mDownloadTask = downloadTask;
-        mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+        } else {
+            mBuilder.setContentIntent(PendingIntent.getActivity(mContext, 200, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT));
+        }
         mBuilder.setSmallIcon(mDownloadTask.getDownloadIcon());
         mBuilder.setTicker(mContext.getString(R.string.download_trickter));
         mBuilder.setContentTitle(title);

--- a/library/src/main/java/com/download/library/DownloadNotifier.java
+++ b/library/src/main/java/com/download/library/DownloadNotifier.java
@@ -143,7 +143,12 @@ public class DownloadNotifier {
     private PendingIntent buildCancelContent(Context context, int id, String url) {
         Intent intentCancel = new Intent(Runtime.getInstance().append(context, NotificationCancelReceiver.ACTION));
         intentCancel.putExtra("TAG", url);
-        PendingIntent pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntentCancel;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        } else {
+            pendingIntentCancel = PendingIntent.getBroadcast(context, id * 1000, intentCancel, PendingIntent.FLAG_UPDATE_CURRENT);
+        }
         Runtime.getInstance().log(TAG, "buildCancelContent id:" + (id * 1000) + " cancal action:" + Runtime.getInstance().append(context, NotificationCancelReceiver.ACTION));
         return pendingIntentCancel;
     }
@@ -284,10 +289,18 @@ public class DownloadNotifier {
                 public void run() {
                     removeCancelAction();
                     setDelecte(null);
-                    PendingIntent rightPendIntent = PendingIntent
-                            .getActivity(mContext,
-                                    mNotificationId * 10000, mIntent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent rightPendIntent;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        rightPendIntent = PendingIntent
+                          .getActivity(mContext,
+                            mNotificationId * 10000, mIntent,
+                            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                    } else {
+                        rightPendIntent = PendingIntent
+                          .getActivity(mContext,
+                            mNotificationId * 10000, mIntent,
+                            PendingIntent.FLAG_UPDATE_CURRENT);
+                    }
                     mBuilder.setSmallIcon(mDownloadTask.getDownloadDoneIcon());
                     mBuilder.setContentText(mContext.getString(R.string.download_click_open));
                     mBuilder.setProgress(100, 100, false);


### PR DESCRIPTION
### fixed a issue below:
> java.lang.IllegalArgumentException: com.mintsoft.hybrid.android: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.